### PR TITLE
[s3] Use async S3 client instead of the sync client

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
         run: |
-          export commit_title=$(git log --pretty=format:%s -1 $COMMIT_HASH
+          export commit_title=$(git log --pretty=format:%s -1 $COMMIT_HASH)
           echo "Commit title: $commit_title"
           if [[ $commit_title =~ ^Release\ version\ [0-9]*\.[0-9]*\.[0-9]*$ ]]; then
             echo "Valid commit title"
@@ -43,13 +43,35 @@ jobs:
         run: |
           ./gradlew distTar distZip
 
-          export tar_file=$(ls ./build/distributions/ | grep tar)
-          export zip_file=$(ls ./build/distributions/ | grep zip)
-          echo tar_file=${tar_file} >> $GITHUB_ENV
-          echo zip_file=${zip_file} >> $GITHUB_ENV
+          # Core libs
+          export core_tar_file=$(ls ./core/build/distributions/ | grep tgz)
+          export core_zip_file=$(ls ./core/build/distributions/ | grep zip)
+          echo core_tar_file=${core_tar_file} >> $GITHUB_ENV
+          echo core_zip_file=${core_zip_file} >> $GITHUB_ENV
+          # S3 libs
+          export s3_tar_file=$(ls ./storage/s3/build/distributions/ | grep tgz)
+          export s3_zip_file=$(ls ./storage/s3/build/distributions/ | grep zip)
+          echo s3_tar_file=${s3_tar_file} >> $GITHUB_ENV
+          echo s3_zip_file=${s3_zip_file} >> $GITHUB_ENV
+          # GCS libs
+          export gcs_tar_file=$(ls ./storage/gcs/build/distributions/ | grep tgz)
+          export gcs_zip_file=$(ls ./storage/gcs/build/distributions/ | grep zip)
+          echo gcs_tar_file=${gcs_tar_file} >> $GITHUB_ENV
+          echo gcs_zip_file=${gcs_zip_file} >> $GITHUB_ENV
+          # Azure libs
+          export azure_tar_file=$(ls ./storage/azure/build/distributions/ | grep tgz)
+          export azure_zip_file=$(ls ./storage/azure/build/distributions/ | grep zip)
+          echo azure_tar_file=${azure_tar_file} >> $GITHUB_ENV
+          echo azure_zip_file=${azure_zip_file} >> $GITHUB_ENV
 
-          echo tar_path=`realpath ./build/distributions/${tar_file}` >> $GITHUB_ENV
-          echo zip_path=`realpath ./build/distributions/${zip_file}` >> $GITHUB_ENV
+          echo core_tar_path=`realpath ./core/build/distributions/${core_tar_file}` >> $GITHUB_ENV
+          echo core_zip_path=`realpath ./core/build/distributions/${core_zip_file}` >> $GITHUB_ENV
+          echo s3_tar_path=`realpath ./storage/s3/build/distributions/${s3_tar_file}` >> $GITHUB_ENV
+          echo s3_zip_path=`realpath ./storage/s3/build/distributions/${s3_zip_file}` >> $GITHUB_ENV
+          echo gcs_tar_path=`realpath ./storage/gcs/build/distributions/${gcs_tar_file}` >> $GITHUB_ENV
+          echo gcs_zip_path=`realpath ./storage/gcs/build/distributions/${gcs_zip_file}` >> $GITHUB_ENV
+          echo azure_tar_path=`realpath ./storage/azure/build/distributions/${azure_tar_file}` >> $GITHUB_ENV
+          echo azure_zip_path=`realpath ./storage/azure/build/distributions/${azure_zip_file}` >> $GITHUB_ENV
 
       - name: Create tag
         env:
@@ -74,22 +96,75 @@ jobs:
           draft: true
           prerelease: false
 
-      - name: Upload tar
+      - name: Upload core tar
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.tar_path }}
-          asset_name: ${{ env.tar_file }}
+          asset_path: ${{ env.core_tar_path }}
+          asset_name: ${{ env.core_tar_file }}
           asset_content_type: application/tar
-
-      - name: Upload zip
+      - name: Upload core zip
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.zip_path }}
-          asset_name: ${{ env.zip_file }}
+          asset_path: ${{ env.core_zip_path }}
+          asset_name: ${{ env.core_zip_file }}
+          asset_content_type: application/zip
+      - name: Upload s3 tar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.s3_tar_path }}
+          asset_name: ${{ env.s3_tar_file }}
+          asset_content_type: application/tar
+      - name: Upload s3 zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.s3_zip_path }}
+          asset_name: ${{ env.s3_zip_file }}
+          asset_content_type: application/zip
+      - name: Upload gcs tar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.gcs_tar_path }}
+          asset_name: ${{ env.gcs_tar_file }}
+          asset_content_type: application/tar
+      - name: Upload gcs zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.gcs_zip_path }}
+          asset_name: ${{ env.gcs_zip_file }}
+          asset_content_type: application/zip
+      - name: Upload azure tar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.azure_tar_path }}
+          asset_name: ${{ env.azure_tar_file }}
+          asset_content_type: application/tar
+      - name: Upload azure zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.azure_zip_path }}
+          asset_name: ${{ env.azure_zip_file }}
           asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ Even in case of sequential reads, chunks may be required multiple times in a sho
 
 The cache is able to asynchronously prefetch next chunks, up to the specified number of bytes. This positively affects sequential read performance. At the moment, prefetching is limited with segment borders, i.e. it cannot prefetch from the following segment.
 
+## SOCKS5 proxy
+
+⚠️ This is an experimental feature subject for future changes.
+
+The Azure storage backend supports SOCKS5 proxy with the proxy-side host name resolution.
+
+The proxy support in other storage backends is in the work.
+
 ## License
 
 The project is licensed under the Apache license, version 2.0. Full license test is available in the [LICENSE](LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -196,9 +196,11 @@ The cache is able to asynchronously prefetch next chunks, up to the specified nu
 
 ⚠️ This is an experimental feature subject for future changes.
 
-The Azure storage backend supports SOCKS5 proxy with the proxy-side host name resolution.
-
-The proxy support in other storage backends is in the work.
+| Object storage       |    Supported    | Host name resolution |
+|----------------------|:---------------:|:--------------------:|
+|        AWS S3        | ❌ (in progress) |                      |
+| Azure Blob Storage   |        ✅        |      Proxy-side      |
+| Google Cloud Storage |        ✅        |      Proxy-side      |
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ subprojects {
 
         jacksonVersion = "2.16.1"
 
-        awaitilityVersion = "4.2.0"
+        awaitilityVersion = "4.2.1"
 
         awsSdkVersion = "2.23.16"
 

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ subprojects {
 
         gcpSdkVersion = "2.32.1"
 
-        azureSdkVersion = "1.2.21"
+        azureSdkVersion = "1.2.22"
 
         testcontainersVersion = "1.19.4"
 

--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ subprojects {
 
         junitVersion = "5.10.2"
 
-        junitPlatformVersion = "1.10.1"
+        junitPlatformVersion = "1.10.2"
 
         mockitoVersion = "5.11.0"
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,7 +22,7 @@ archivesBaseName = "core"
 ext {
     // Keep empty lines between versions to avoid conflicts on mass update (e.g. Dependabot).
 
-    bouncyCastleVersion = "1.76"
+    bouncyCastleVersion = "1.77"
 
     caffeineVersion = "3.1.8"
 

--- a/core/src/integration-test/java/io/aiven/kafka/tieredstorage/AllOpenedFileInputStreamsAreClosedChecker.java
+++ b/core/src/integration-test/java/io/aiven/kafka/tieredstorage/AllOpenedFileInputStreamsAreClosedChecker.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Checks that all {@link InputStream}s opened by
+ * {@link Files#newInputStream(Path, OpenOption...)} are properly closed.
+ *
+ * <p>Should be used in try-with-resources.
+ */
+class AllOpenedFileInputStreamsAreClosedChecker implements AutoCloseable {
+    private final MockedStatic<Files> mockedFiles;
+
+    private final List<InputStream> opened = Collections.synchronizedList(new ArrayList<>());
+
+    public AllOpenedFileInputStreamsAreClosedChecker() {
+        this.mockedFiles = Mockito.mockStatic(Files.class, CALLS_REAL_METHODS);
+        this.mockedFiles.when(() -> Files.newInputStream(any(Path.class)))
+            .thenAnswer(invocation -> {
+                final InputStream spy = Mockito.spy((InputStream) invocation.callRealMethod());
+                opened.add(spy);
+                return spy;
+            });
+    }
+
+    @Override
+    public void close() throws IOException {
+        mockedFiles.close();
+
+        assert !opened.isEmpty();
+        for (final InputStream spy : opened) {
+            verify(spy).close();
+        }
+    }
+}

--- a/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
+++ b/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
@@ -226,8 +226,10 @@ class RemoteStorageManagerTest extends RsaKeyAwareTest {
         final LogSegmentData logSegmentData = new LogSegmentData(
             logFilePath, offsetIndexFilePath, timeIndexFilePath, txnIndexPath,
             producerSnapshotFilePath, ByteBuffer.wrap(LEADER_EPOCH_INDEX_BYTES));
-        final Optional<RemoteLogSegmentMetadata.CustomMetadata> customMetadata =
-            rsm.copyLogSegmentData(REMOTE_LOG_METADATA, logSegmentData);
+        final Optional<RemoteLogSegmentMetadata.CustomMetadata> customMetadata;
+        try (final var checker = new AllOpenedFileInputStreamsAreClosedChecker()) {
+            customMetadata = rsm.copyLogSegmentData(REMOTE_LOG_METADATA, logSegmentData);
+        }
 
         checkCustomMetadata(customMetadata);
         checkFilesInTargetDirectory();

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/ClosableInputStreamHolder.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/ClosableInputStreamHolder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ClosableInputStreamHolder implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(ClosableInputStreamHolder.class);
+
+    private final List<InputStream> streams = new ArrayList<>();
+
+    InputStream add(final InputStream is) {
+        this.streams.add(is);
+        return is;
+    }
+
+    @Override
+    public void close() {
+        for (final InputStream is : streams) {
+            try {
+                is.close();
+            } catch (final IOException e) {
+                // We want to close all of them or, in case of an error closing some, as much as possible.
+                // So no rethrowing, only logging.
+                log.error("Error closing InputStream", e);
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/ClosableInputStreamHolderTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/ClosableInputStreamHolderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class ClosableInputStreamHolderTest {
+    @Test
+    void closeAll() throws IOException {
+        final InputStream is1 = mock(InputStream.class);
+        final InputStream is2 = mock(InputStream.class);
+        final InputStream is3 = mock(InputStream.class);
+        try (final var holder = new ClosableInputStreamHolder()) {
+            holder.add(is1);
+            holder.add(is2);
+            holder.add(is3);
+        }
+        verify(is1).close();
+        verify(is2).close();
+        verify(is3).close();
+    }
+
+    @Test
+    void closeAllEvenWithErrors() throws IOException {
+        final InputStream is1 = mock(InputStream.class);
+        final InputStream is2 = mock(InputStream.class);
+        doThrow(new IOException("test")).when(is2).close();
+        final InputStream is3 = mock(InputStream.class);
+
+        try (final var holder = new ClosableInputStreamHolder()) {
+            holder.add(is1);
+            holder.add(is2);
+            holder.add(is3);
+        }
+        verify(is1).close();
+        verify(is2).close();
+        verify(is3).close();
+    }
+}

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/AzureSingleBrokerDirectTest.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/AzureSingleBrokerDirectTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.e2e;
+
+import com.azure.storage.blob.BlobContainerClient;
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * The Azure Blob Storage test variant that goes to Azurite directly (i.e. not through the SOCKS5 proxy).
+ */
+class AzureSingleBrokerDirectTest extends AzureSingleBrokerTest {
+    private static final String AZURE_CONTAINER = "test-container-direct";
+
+    @BeforeAll
+    static void createAzureContainer() {
+        blobServiceClient.createBlobContainer(AZURE_CONTAINER);
+    }
+
+    @BeforeAll
+    static void startKafka() throws Exception {
+        setupKafka(kafka -> rsmPluginBasicSetup(kafka)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_AZURE_CONTAINER_NAME", AZURE_CONTAINER));
+    }
+
+    @Override
+    BlobContainerClient blobContainerClient() {
+        return blobServiceClient.getBlobContainerClient(AZURE_CONTAINER);
+    }
+}

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/AzureSingleBrokerSocks5Test.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/AzureSingleBrokerSocks5Test.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.e2e;
+
+import com.azure.storage.blob.BlobContainerClient;
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * The Azure Blob Storage test variant that goes to Azurite through the SOCKS5 proxy.
+ */
+class AzureSingleBrokerSocks5Test extends AzureSingleBrokerTest {
+    private static final String AZURE_CONTAINER = "test-container-socks5";
+
+    @BeforeAll
+    static void createAzureContainer() {
+        blobServiceClient.createBlobContainer(AZURE_CONTAINER);
+    }
+
+    @BeforeAll
+    static void startKafka() throws Exception {
+        setupKafka(kafka -> rsmPluginBasicSetup(kafka)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_AZURE_CONTAINER_NAME", AZURE_CONTAINER)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_PROXY_HOST", SOCKS5_NETWORK_ALIAS)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_PROXY_PORT", Integer.toString(SOCKS5_PORT))
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_PROXY_USERNAME", SOCKS5_USER)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_PROXY_PASSWORD", SOCKS5_PASSWORD)
+        );
+    }
+
+    @Override
+    BlobContainerClient blobContainerClient() {
+        return blobServiceClient.getBlobContainerClient(AZURE_CONTAINER);
+    }
+}

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/AzureSingleBrokerTest.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/AzureSingleBrokerTest.java
@@ -23,59 +23,47 @@ import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 
 import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.ListBlobsOptions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
-public class AzureSingleBrokerTest extends SingleBrokerTest {
-    private static final int BLOB_STORAGE_PORT = 10000;
-    static final String NETWORK_ALIAS = "blob-storage";
+abstract class AzureSingleBrokerTest extends SingleBrokerTest {
+    static final int BLOB_STORAGE_PORT = 10000;
+    static final String AZURITE_NETWORK_ALIAS = "blob-storage";
+
+    // The well-known Azurite account name and key.
+    static final String ACCOUNT_NAME = "devstoreaccount1";
+    static final String ACCOUNT_KEY =
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
 
     static final GenericContainer<?> AZURITE_SERVER =
         new GenericContainer<>(DockerImageName.parse("mcr.microsoft.com/azure-storage/azurite"))
             .withExposedPorts(BLOB_STORAGE_PORT)
             .withCommand("azurite-blob --blobHost 0.0.0.0")
             .withNetwork(NETWORK)
-            .withNetworkAliases(NETWORK_ALIAS);
+            .withNetworkAliases(AZURITE_NETWORK_ALIAS);
 
-    static final String AZURE_CONTAINER = "test-container";
-
-    static BlobContainerClient blobContainerClient;
+    static BlobServiceClient blobServiceClient;
 
     @BeforeAll
-    static void init() throws Exception {
+    static void init() {
         AZURITE_SERVER.start();
-
-        // The well-known Azurite account name and key.
-        final String accountName = "devstoreaccount1";
-        final String accountKey =
-            "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
 
         final String endpointForTestCode =
             "http://127.0.0.1:" + AZURITE_SERVER.getMappedPort(BLOB_STORAGE_PORT) + "/devstoreaccount1";
         final String connectionString = "DefaultEndpointsProtocol=http;"
-            + "AccountName=" + accountName + ";"
-            + "AccountKey=" + accountKey + ";"
+            + "AccountName=" + ACCOUNT_NAME + ";"
+            + "AccountKey=" + ACCOUNT_KEY + ";"
             + "BlobEndpoint=" + endpointForTestCode + ";";
-        final var blobServiceClient = new BlobServiceClientBuilder()
+        blobServiceClient = new BlobServiceClientBuilder()
             .connectionString(connectionString)
             .buildClient();
-        blobContainerClient = blobServiceClient.createBlobContainer(AZURE_CONTAINER);
-
-        final String endpointForKafka = "http://" + NETWORK_ALIAS + ":" + BLOB_STORAGE_PORT + "/devstoreaccount1";
-        setupKafka(kafka -> kafka.withEnv("KAFKA_RSM_CONFIG_STORAGE_BACKEND_CLASS",
-                "io.aiven.kafka.tieredstorage.storage.azure.AzureBlobStorage")
-            .withEnv("KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_PATH",
-                "/tiered-storage-for-apache-kafka/core/*:/tiered-storage-for-apache-kafka/azure/*")
-            .withEnv("KAFKA_RSM_CONFIG_STORAGE_AZURE_CONTAINER_NAME", AZURE_CONTAINER)
-            .withEnv("KAFKA_RSM_CONFIG_STORAGE_AZURE_ACCOUNT_NAME", accountName)
-            .withEnv("KAFKA_RSM_CONFIG_STORAGE_AZURE_ACCOUNT_KEY", accountKey)
-            .withEnv("KAFKA_RSM_CONFIG_STORAGE_AZURE_ENDPOINT_URL", endpointForKafka)
-            .dependsOn(AZURITE_SERVER));
     }
 
     @AfterAll
@@ -87,17 +75,35 @@ public class AzureSingleBrokerTest extends SingleBrokerTest {
         cleanupStorage();
     }
 
+    static KafkaContainer rsmPluginBasicSetup(final KafkaContainer container) {
+        final String endpointForKafka = "http://" + AZURITE_NETWORK_ALIAS + ":" + BLOB_STORAGE_PORT + "/devstoreaccount1";
+
+        container
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_BACKEND_CLASS",
+                "io.aiven.kafka.tieredstorage.storage.azure.AzureBlobStorage")
+            .withEnv("KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_PATH",
+                "/tiered-storage-for-apache-kafka/core/*:/tiered-storage-for-apache-kafka/azure/*")
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_AZURE_ENDPOINT_URL", endpointForKafka)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_AZURE_ACCOUNT_NAME", ACCOUNT_NAME)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_AZURE_ACCOUNT_KEY", ACCOUNT_KEY)
+
+            .dependsOn(AZURITE_SERVER);
+        return container;
+    }
+
+    abstract BlobContainerClient blobContainerClient();
+
     @Override
     boolean assertNoTopicDataOnTierStorage(final String topicName, final Uuid topicId) {
         final String prefix = String.format("%s-%s", topicName, topicId.toString());
 
-        final var list = blobContainerClient.listBlobs(new ListBlobsOptions().setPrefix(prefix), null);
+        final var list = blobContainerClient().listBlobs(new ListBlobsOptions().setPrefix(prefix), null);
         return list.stream().findAny().isEmpty();
     }
 
     @Override
     List<String> remotePartitionFiles(final TopicIdPartition topicIdPartition) {
-        return blobContainerClient.listBlobs().stream()
+        return blobContainerClient().listBlobs().stream()
             .map(BlobItem::getName)
             .map(k -> k.substring(k.lastIndexOf('/') + 1))
             .sorted()

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/GcsSingleBrokerDirectTest.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/GcsSingleBrokerDirectTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.e2e;
+
+import com.google.cloud.storage.BucketInfo;
+import org.junit.jupiter.api.BeforeAll;
+
+public class GcsSingleBrokerDirectTest extends GcsSingleBrokerTest {
+    static final String BUCKET = "test-bucket-direct";
+
+    @BeforeAll
+    static void createBucket() {
+        gcsClient.create(BucketInfo.newBuilder(BUCKET).build());
+    }
+
+    @BeforeAll
+    static void startKafka() throws Exception {
+        setupKafka(kafka -> rsmPluginBasicSetup(kafka)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_GCS_BUCKET_NAME", BUCKET));
+    }
+
+    @Override
+    protected String bucket() {
+        return BUCKET;
+    }
+}

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/GcsSingleBrokerSocks5Test.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/GcsSingleBrokerSocks5Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.e2e;
+
+import com.google.cloud.storage.BucketInfo;
+import org.junit.jupiter.api.BeforeAll;
+
+public class GcsSingleBrokerSocks5Test extends GcsSingleBrokerTest {
+    static final String BUCKET = "test-bucket-socks5";
+
+    @BeforeAll
+    static void createBucket() {
+        gcsClient.create(BucketInfo.newBuilder(BUCKET).build());
+    }
+
+    @BeforeAll
+    static void startKafka() throws Exception {
+        setupKafka(kafka -> rsmPluginBasicSetup(kafka)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_GCS_BUCKET_NAME", BUCKET)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_PROXY_HOST", SOCKS5_NETWORK_ALIAS)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_PROXY_PORT", Integer.toString(SOCKS5_PORT))
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_PROXY_USERNAME", SOCKS5_USER)
+            .withEnv("KAFKA_RSM_CONFIG_STORAGE_PROXY_PASSWORD", SOCKS5_PASSWORD));
+    }
+
+    @Override
+    protected String bucket() {
+        return BUCKET;
+    }
+}

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
@@ -66,9 +66,11 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestWatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
@@ -82,7 +84,6 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(SingleBrokerTest.FailFastExtension.class)
 abstract class SingleBrokerTest {
-
     static final Logger LOG = LoggerFactory.getLogger(SingleBrokerTest.class);
 
     static final String KAFKA_DATA_SUBDIR_HOST = "data";
@@ -107,6 +108,23 @@ abstract class SingleBrokerTest {
     static final Duration TOTAL_RETENTION = Duration.ofHours(1);
     static final Duration LOCAL_RETENTION = Duration.ofSeconds(5);
     static final Network NETWORK = Network.newNetwork();
+
+    static final String SOCKS5_NETWORK_ALIAS = "socks5-proxy";
+    static final int SOCKS5_PORT = 1080;
+    static final String SOCKS5_USER = "user";
+    static final String SOCKS5_PASSWORD = "password";
+
+    @Container
+    static final GenericContainer<?> SOCKS5_PROXY =
+        new GenericContainer<>(DockerImageName.parse("ananclub/ss5"))
+            .withEnv(Map.of(
+                "LISTEN", "0.0.0.0:" + SOCKS5_PORT,
+                "USER", SOCKS5_USER,
+                "PASSWORD", SOCKS5_PASSWORD
+            ))
+            .withExposedPorts(SOCKS5_PORT)
+            .withNetwork(NETWORK)
+            .withNetworkAliases(SOCKS5_NETWORK_ALIAS);
 
     static Path baseDir;
     // Can't use @TempDir, because it's initialized too late.

--- a/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageMetricsTest.java
+++ b/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageMetricsTest.java
@@ -32,6 +32,7 @@ import io.aiven.kafka.tieredstorage.storage.ObjectKey;
 import io.aiven.kafka.tieredstorage.storage.StorageBackend;
 import io.aiven.kafka.tieredstorage.storage.StorageBackendException;
 import io.aiven.kafka.tieredstorage.storage.TestObjectKey;
+import io.aiven.kafka.tieredstorage.storage.TestUtils;
 
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
@@ -73,17 +74,7 @@ public class AzureBlobStorageMetricsTest {
 
     @BeforeEach
     void setUp(final TestInfo testInfo) {
-        azureContainerName = testInfo.getDisplayName()
-            .toLowerCase()
-            .replace(" ", "")
-            .replace(",", "-")
-            .replace("(", "")
-            .replace(")", "")
-            .replace("[", "")
-            .replace("]", "");
-        while (azureContainerName.length() < 3) {
-            azureContainerName += azureContainerName;
-        }
+        azureContainerName = TestUtils.testNameToBucketName(testInfo);
         blobServiceClient.createBlobContainer(azureContainerName);
     }
 

--- a/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageSocks5Test.java
+++ b/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageSocks5Test.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.aiven.kafka.tieredstorage.storage.BaseSocks5Test;
+import io.aiven.kafka.tieredstorage.storage.TestUtils;
 
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
@@ -74,13 +75,7 @@ class AzureBlobStorageSocks5Test extends BaseSocks5Test<AzureBlobStorage> {
 
     @BeforeEach
     void setUp(final TestInfo testInfo) {
-        azureContainerName = testInfo.getDisplayName()
-            .toLowerCase()
-            .replace("(", "")
-            .replace(")", "");
-        while (azureContainerName.length() < 3) {
-            azureContainerName += azureContainerName;
-        }
+        azureContainerName = TestUtils.testNameToBucketName(testInfo);
         blobServiceClient.createBlobContainer(azureContainerName);
     }
 

--- a/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageSocks5Test.java
+++ b/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageSocks5Test.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.azure;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import io.aiven.kafka.tieredstorage.storage.ObjectKey;
+import io.aiven.kafka.tieredstorage.storage.StorageBackendException;
+
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import static io.aiven.kafka.tieredstorage.storage.azure.AzuriteBlobStorageUtils.azuriteContainer;
+import static io.aiven.kafka.tieredstorage.storage.azure.AzuriteBlobStorageUtils.connectionString;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Testcontainers
+class AzureBlobStorageSocks5Test {
+    protected static final int SOCKS5_PORT = 1080;
+    protected static final String SOCKS5_USER = "user";
+    protected static final String SOCKS5_PASSWORD = "password";
+
+    protected static final ObjectKey OBJECT_KEY = () -> "aaa";
+    protected static final byte[] TEST_DATA = {0, 1, 2, 3};
+
+    static final Network NETWORK = Network.newNetwork();
+
+    static final int BLOB_STORAGE_PORT = 10000;
+    @Container
+    static final GenericContainer<?> AZURITE_SERVER = azuriteContainer(BLOB_STORAGE_PORT)
+        .withNetwork(NETWORK);
+
+    @Container
+    static final GenericContainer<?> PROXY_AUTHENTICATED =
+        new GenericContainer<>(DockerImageName.parse("ananclub/ss5"))
+            .withEnv(Map.of(
+                "LISTEN", "0.0.0.0:" + SOCKS5_PORT,
+                "USER", SOCKS5_USER,
+                "PASSWORD", SOCKS5_PASSWORD
+            ))
+            .withExposedPorts(SOCKS5_PORT)
+            .withNetwork(NETWORK);
+
+    @Container
+    static final GenericContainer<?> PROXY_UNAUTHENTICATED =
+        new GenericContainer<>(DockerImageName.parse("ananclub/ss5"))
+            .withEnv(Map.of(
+                "LISTEN", "0.0.0.0:" + SOCKS5_PORT
+            ))
+            .withExposedPorts(SOCKS5_PORT)
+            .withNetwork(NETWORK);
+
+    static BlobServiceClient blobServiceClient;
+
+    static String azuriteContainerNetworkAlias = AZURITE_SERVER.getNetworkAliases().get(0);
+
+    // This endpoint points to Azurite with the Docker-internal hostname and port.
+    // The host running these tests cannot reach it directly, only via a proxy.
+    static String internalConnectionString;
+
+    protected String azureContainerName;
+
+    @BeforeAll
+    static void setUpClass() {
+        final String connectionStringWithMappedPort = connectionString(AZURITE_SERVER, BLOB_STORAGE_PORT);
+        blobServiceClient = new BlobServiceClientBuilder()
+            .connectionString(connectionStringWithMappedPort)
+            .buildClient();
+
+        internalConnectionString = "DefaultEndpointsProtocol=http;"
+            + "AccountName=devstoreaccount1;"
+            + "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
+            + "BlobEndpoint=" + String.format("http://%s:%d/devstoreaccount1", azuriteContainerNetworkAlias, BLOB_STORAGE_PORT) + ";";
+    }
+
+    @BeforeEach
+    void setUp(final TestInfo testInfo) {
+        azureContainerName = testInfo.getDisplayName()
+            .toLowerCase()
+            .replace("(", "")
+            .replace(")", "");
+        while (azureContainerName.length() < 3) {
+            azureContainerName += azureContainerName;
+        }
+        blobServiceClient.createBlobContainer(azureContainerName);
+    }
+
+    @Test
+    void worksWithAuthenticatedProxy() throws StorageBackendException, IOException {
+        // Ensure we can access the storage through the proxy with authentication.
+        final var proxy = PROXY_AUTHENTICATED;
+        final AzureBlobStorage storage = new AzureBlobStorage();
+        storage.configure(Map.of(
+            "azure.container.name", azureContainerName,
+            "azure.connection.string", internalConnectionString,
+            "proxy.host", proxy.getHost(),
+            "proxy.port", proxy.getMappedPort(SOCKS5_PORT),
+            "proxy.username", SOCKS5_USER,
+            "proxy.password", SOCKS5_PASSWORD
+        ));
+
+        storage.upload(new ByteArrayInputStream(TEST_DATA), OBJECT_KEY);
+        assertThat(storage.fetch(OBJECT_KEY).readAllBytes()).isEqualTo(TEST_DATA);
+    }
+
+    @Test
+    void worksWithUnauthenticatedProxy() throws StorageBackendException, IOException {
+        // Ensure we can access the storage through the proxy without authentication.
+        final var proxy = PROXY_UNAUTHENTICATED;
+        final AzureBlobStorage storage = new AzureBlobStorage();
+        storage.configure(Map.of(
+            "azure.container.name", azureContainerName,
+            "azure.connection.string", internalConnectionString,
+            "proxy.host", proxy.getHost(),
+            "proxy.port", proxy.getMappedPort(SOCKS5_PORT)
+        ));
+
+        storage.upload(new ByteArrayInputStream(TEST_DATA), OBJECT_KEY);
+        assertThat(storage.fetch(OBJECT_KEY).readAllBytes()).isEqualTo(TEST_DATA);
+    }
+
+    @Test
+    void doesNotWorkWithoutProxy() {
+        // This test accompanies the other ones by ensuring that _without_ a proxy
+        // we cannot even resolve the host name of the server, which is internal to the Docker network.
+
+        // Due to the nature to the Java name resolution and/or getaddrinfo,
+        // this has a pretty long unconfigurable timeout, so the test may take a couple of minutes.
+
+        final AzureBlobStorage storage = new AzureBlobStorage();
+        storage.configure(Map.of(
+            "azure.container.name", azureContainerName,
+            "azure.connection.string", internalConnectionString
+        ));
+
+        // Either - or, it seems it depends on the JVM version.
+        final String possibleMessage1 = String.format(
+            "%s: Temporary failure in name resolution", azuriteContainerNetworkAlias);
+        final String possibleMessage2 = String.format("%s: Name or service not known", azuriteContainerNetworkAlias);
+        assertThatThrownBy(() -> storage.upload(new ByteArrayInputStream(new byte[] {0, 1, 2, 3}), OBJECT_KEY))
+            .isExactlyInstanceOf(StorageBackendException.class)
+            .hasRootCauseInstanceOf(UnknownHostException.class)
+            .rootCause().message()
+            .isIn(possibleMessage1, possibleMessage2);
+        assertThatThrownBy(() -> storage.fetch(OBJECT_KEY))
+            .isExactlyInstanceOf(StorageBackendException.class)
+            .hasRootCauseInstanceOf(UnknownHostException.class)
+            .rootCause().message()
+            .isIn(possibleMessage1, possibleMessage2);
+    }
+}

--- a/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageSocks5Test.java
+++ b/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageSocks5Test.java
@@ -16,40 +16,26 @@
 
 package io.aiven.kafka.tieredstorage.storage.azure;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Map;
 
-import io.aiven.kafka.tieredstorage.storage.ObjectKey;
-import io.aiven.kafka.tieredstorage.storage.StorageBackendException;
+import io.aiven.kafka.tieredstorage.storage.BaseSocks5Test;
 
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import static io.aiven.kafka.tieredstorage.storage.azure.AzuriteBlobStorageUtils.azuriteContainer;
 import static io.aiven.kafka.tieredstorage.storage.azure.AzuriteBlobStorageUtils.connectionString;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @Testcontainers
-class AzureBlobStorageSocks5Test {
-    protected static final int SOCKS5_PORT = 1080;
-    protected static final String SOCKS5_USER = "user";
-    protected static final String SOCKS5_PASSWORD = "password";
-
-    protected static final ObjectKey OBJECT_KEY = () -> "aaa";
-    protected static final byte[] TEST_DATA = {0, 1, 2, 3};
-
+class AzureBlobStorageSocks5Test extends BaseSocks5Test<AzureBlobStorage> {
     static final Network NETWORK = Network.newNetwork();
 
     static final int BLOB_STORAGE_PORT = 10000;
@@ -57,35 +43,21 @@ class AzureBlobStorageSocks5Test {
     static final GenericContainer<?> AZURITE_SERVER = azuriteContainer(BLOB_STORAGE_PORT)
         .withNetwork(NETWORK);
 
-    @Container
-    static final GenericContainer<?> PROXY_AUTHENTICATED =
-        new GenericContainer<>(DockerImageName.parse("ananclub/ss5"))
-            .withEnv(Map.of(
-                "LISTEN", "0.0.0.0:" + SOCKS5_PORT,
-                "USER", SOCKS5_USER,
-                "PASSWORD", SOCKS5_PASSWORD
-            ))
-            .withExposedPorts(SOCKS5_PORT)
-            .withNetwork(NETWORK);
+    static String azuriteContainerNetworkAlias = AZURITE_SERVER.getNetworkAliases().get(0);
 
     @Container
-    static final GenericContainer<?> PROXY_UNAUTHENTICATED =
-        new GenericContainer<>(DockerImageName.parse("ananclub/ss5"))
-            .withEnv(Map.of(
-                "LISTEN", "0.0.0.0:" + SOCKS5_PORT
-            ))
-            .withExposedPorts(SOCKS5_PORT)
-            .withNetwork(NETWORK);
+    static final GenericContainer<?> PROXY_AUTHENTICATED = proxyContainer(true).withNetwork(NETWORK);
+    @Container
+    static final GenericContainer<?> PROXY_UNAUTHENTICATED = proxyContainer(false).withNetwork(NETWORK);
 
     static BlobServiceClient blobServiceClient;
 
-    static String azuriteContainerNetworkAlias = AZURITE_SERVER.getNetworkAliases().get(0);
+    // This is an Azure container (AKA bucket), not a Docker container.
+    protected String azureContainerName;
 
     // This endpoint points to Azurite with the Docker-internal hostname and port.
     // The host running these tests cannot reach it directly, only via a proxy.
     static String internalConnectionString;
-
-    protected String azureContainerName;
 
     @BeforeAll
     static void setUpClass() {
@@ -112,67 +84,49 @@ class AzureBlobStorageSocks5Test {
         blobServiceClient.createBlobContainer(azureContainerName);
     }
 
-    @Test
-    void worksWithAuthenticatedProxy() throws StorageBackendException, IOException {
-        // Ensure we can access the storage through the proxy with authentication.
+    @Override
+    protected AzureBlobStorage createStorageBackend() {
+        return new AzureBlobStorage();
+    }
+
+    @Override
+    protected Map<String, Object> storageConfigForAuthenticatedProxy() {
         final var proxy = PROXY_AUTHENTICATED;
-        final AzureBlobStorage storage = new AzureBlobStorage();
-        storage.configure(Map.of(
+        return Map.of(
             "azure.container.name", azureContainerName,
             "azure.connection.string", internalConnectionString,
             "proxy.host", proxy.getHost(),
             "proxy.port", proxy.getMappedPort(SOCKS5_PORT),
             "proxy.username", SOCKS5_USER,
             "proxy.password", SOCKS5_PASSWORD
-        ));
-
-        storage.upload(new ByteArrayInputStream(TEST_DATA), OBJECT_KEY);
-        assertThat(storage.fetch(OBJECT_KEY).readAllBytes()).isEqualTo(TEST_DATA);
+        );
     }
 
-    @Test
-    void worksWithUnauthenticatedProxy() throws StorageBackendException, IOException {
-        // Ensure we can access the storage through the proxy without authentication.
+    @Override
+    protected Map<String, Object> storageConfigForUnauthenticatedProxy() {
         final var proxy = PROXY_UNAUTHENTICATED;
-        final AzureBlobStorage storage = new AzureBlobStorage();
-        storage.configure(Map.of(
+        return Map.of(
             "azure.container.name", azureContainerName,
             "azure.connection.string", internalConnectionString,
             "proxy.host", proxy.getHost(),
             "proxy.port", proxy.getMappedPort(SOCKS5_PORT)
-        ));
-
-        storage.upload(new ByteArrayInputStream(TEST_DATA), OBJECT_KEY);
-        assertThat(storage.fetch(OBJECT_KEY).readAllBytes()).isEqualTo(TEST_DATA);
+        );
     }
 
-    @Test
-    void doesNotWorkWithoutProxy() {
-        // This test accompanies the other ones by ensuring that _without_ a proxy
-        // we cannot even resolve the host name of the server, which is internal to the Docker network.
-
-        // Due to the nature to the Java name resolution and/or getaddrinfo,
-        // this has a pretty long unconfigurable timeout, so the test may take a couple of minutes.
-
-        final AzureBlobStorage storage = new AzureBlobStorage();
-        storage.configure(Map.of(
+    @Override
+    protected Map<String, Object> storageConfigForNoProxy() {
+        return Map.of(
             "azure.container.name", azureContainerName,
             "azure.connection.string", internalConnectionString
-        ));
+        );
+    }
 
+    @Override
+    protected Iterable<String> possibleRootCauseMessagesWhenNoProxy() {
         // Either - or, it seems it depends on the JVM version.
         final String possibleMessage1 = String.format(
             "%s: Temporary failure in name resolution", azuriteContainerNetworkAlias);
         final String possibleMessage2 = String.format("%s: Name or service not known", azuriteContainerNetworkAlias);
-        assertThatThrownBy(() -> storage.upload(new ByteArrayInputStream(new byte[] {0, 1, 2, 3}), OBJECT_KEY))
-            .isExactlyInstanceOf(StorageBackendException.class)
-            .hasRootCauseInstanceOf(UnknownHostException.class)
-            .rootCause().message()
-            .isIn(possibleMessage1, possibleMessage2);
-        assertThatThrownBy(() -> storage.fetch(OBJECT_KEY))
-            .isExactlyInstanceOf(StorageBackendException.class)
-            .hasRootCauseInstanceOf(UnknownHostException.class)
-            .rootCause().message()
-            .isIn(possibleMessage1, possibleMessage2);
+        return List.of(possibleMessage1, possibleMessage2);
     }
 }

--- a/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageTest.java
+++ b/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageTest.java
@@ -22,6 +22,7 @@ import io.aiven.kafka.tieredstorage.storage.BaseStorageTest;
 import io.aiven.kafka.tieredstorage.storage.BytesRange;
 import io.aiven.kafka.tieredstorage.storage.InvalidRangeException;
 import io.aiven.kafka.tieredstorage.storage.StorageBackendException;
+import io.aiven.kafka.tieredstorage.storage.TestUtils;
 
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
@@ -55,13 +56,7 @@ abstract class AzureBlobStorageTest extends BaseStorageTest {
 
     @BeforeEach
     void setUp(final TestInfo testInfo) {
-        azureContainerName = testInfo.getDisplayName()
-            .toLowerCase()
-            .replace("(", "")
-            .replace(")", "");
-        while (azureContainerName.length() < 3) {
-            azureContainerName += azureContainerName;
-        }
+        azureContainerName = TestUtils.testNameToBucketName(testInfo);
         blobServiceClient.createBlobContainer(azureContainerName);
     }
 

--- a/storage/azure/src/main/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageConfig.java
+++ b/storage/azure/src/main/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageConfig.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.config.types.Password;
 import io.aiven.kafka.tieredstorage.config.validators.NonEmptyPassword;
 import io.aiven.kafka.tieredstorage.config.validators.Null;
 import io.aiven.kafka.tieredstorage.config.validators.ValidUrl;
+import io.aiven.kafka.tieredstorage.storage.proxy.ProxyConfig;
 
 public class AzureBlobStorageConfig extends AbstractConfig {
     static final String AZURE_ACCOUNT_NAME_CONFIG = "azure.account.name";
@@ -108,9 +109,20 @@ public class AzureBlobStorageConfig extends AbstractConfig {
                 AZURE_UPLOAD_BLOCK_SIZE_DOC);
     }
 
+    private ProxyConfig proxyConfig = null;
+
     public AzureBlobStorageConfig(final Map<String, ?> props) {
         super(CONFIG, props);
         validate();
+
+        final Map<String, ?> proxyProps = this.originalsWithPrefix(ProxyConfig.PROXY_PREFIX, true);
+        if (!proxyProps.isEmpty()) {
+            this.proxyConfig = new ProxyConfig(proxyProps);
+        }
+    }
+
+    ProxyConfig proxyConfig() {
+        return proxyConfig;
     }
 
     private void validate() {

--- a/storage/core/build.gradle
+++ b/storage/core/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     testFixturesImplementation "org.assertj:assertj-core:$assertJVersion"
 
     testFixturesImplementation "org.apache.kafka:kafka-clients:$kafkaVersion"
+
+    testFixturesImplementation "org.testcontainers:junit-jupiter:$testcontainersVersion"
 }
 
 components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }

--- a/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/proxy/ProxyConfig.java
+++ b/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/proxy/ProxyConfig.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.proxy;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+public class ProxyConfig extends AbstractConfig {
+    public static final String PROXY_PREFIX = "proxy.";
+
+    private static final String PROXY_HOST = "host";
+    private static final String PROXY_HOST_DOC = "The SOCKS5 proxy host name or IP address";
+
+    private static final String PROXY_PORT = "port";
+    private static final String PROXY_PORT_DOC = "The SOCKS5 proxy port";
+
+    private static final String PROXY_USERNAME = "username";
+    private static final String PROXY_USERNAME_DOC = "The username for authentication at the SOCKS5 proxy";
+
+    private static final String PROXY_PASSWORD = "password";
+    private static final String PROXY_PASSWORD_DOC = "The password for authentication at the SOCKS5 proxy";
+
+    private static final ConfigDef CONFIG;
+
+    static {
+        CONFIG = new ConfigDef();
+
+        CONFIG.define(
+            PROXY_HOST,
+            ConfigDef.Type.STRING,
+            ConfigDef.NO_DEFAULT_VALUE,
+            ConfigDef.Importance.LOW,
+            PROXY_HOST_DOC
+        );
+
+        CONFIG.define(
+            PROXY_PORT,
+            ConfigDef.Type.INT,
+            ConfigDef.NO_DEFAULT_VALUE,
+            ConfigDef.Importance.LOW,
+            PROXY_PORT_DOC
+        );
+
+        CONFIG.define(
+            PROXY_USERNAME,
+            ConfigDef.Type.PASSWORD,
+            null,
+            ConfigDef.Importance.LOW,
+            PROXY_USERNAME_DOC
+        );
+
+        CONFIG.define(
+            PROXY_PASSWORD,
+            ConfigDef.Type.PASSWORD,
+            null,
+            ConfigDef.Importance.LOW,
+            PROXY_PASSWORD_DOC
+        );
+    }
+
+    public ProxyConfig(final Map<String, ?> props) {
+        super(CONFIG, props);
+        validate();
+    }
+
+    private void validate() {
+        if (username() == null && password() != null || username() != null && password() == null) {
+            throw new ConfigException("Username and password must be provided together");
+        }
+    }
+
+    public String host() {
+        return getString(PROXY_HOST);
+    }
+
+    public int port() {
+        return getInt(PROXY_PORT);
+    }
+
+    public String username() {
+        final var secret = getPassword(PROXY_USERNAME);
+        return secret != null ? secret.value() : null;
+    }
+
+    public String password() {
+        final var secret = getPassword(PROXY_PASSWORD);
+        return secret != null ? secret.value() : null;
+    }
+}

--- a/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/proxy/Socks5ProxyAuthenticator.java
+++ b/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/proxy/Socks5ProxyAuthenticator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.proxy;
+
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.util.HashMap;
+import java.util.Objects;
+
+/**
+ * The static authenticator for SOCKS5 proxies.
+ *
+ * <p>Due how this is implemented in Java, the authenticator is static. This is far from ideal,
+ * but lacking a better option, we can live with this: Kafka installations shouldn't have other authenticators.
+ */
+public class Socks5ProxyAuthenticator extends Authenticator {
+    /**
+     * Register the credentials with the authenticator.
+     *
+     * <p>If this authenticator is not installed as the default in the runtime, it will be.
+     */
+    public static synchronized void register(
+        final String host, final int port, final String username, final String password
+    ) {
+        final Authenticator currentDefault = Authenticator.getDefault();
+        if (currentDefault != null) {
+            if (!(currentDefault instanceof Socks5ProxyAuthenticator)) {
+                // This is not really expected to happen in Kafka installations.
+                throw new RuntimeException("Another Authenticator already registered");
+            }
+            ((Socks5ProxyAuthenticator) currentDefault).addCredentials(host, port, username, password);
+        } else {
+            final Socks5ProxyAuthenticator authenticator = new Socks5ProxyAuthenticator();
+            Authenticator.setDefault(authenticator);
+            authenticator.addCredentials(host, port, username, password);
+        }
+    }
+
+    private final HashMap<InetSocketAddress, PasswordAuthentication> credentials = new HashMap<>();
+
+    void addCredentials(final String host, final int port, final String username, final String password) {
+        Objects.requireNonNull(host, "host cannot be null");
+        if (port <= 0) {
+            throw new IllegalArgumentException("port must be positive");
+        }
+        Objects.requireNonNull(username, "username cannot be null");
+        Objects.requireNonNull(password, "password cannot be null");
+
+        // InetSocketAddress is just a tuple holder in this case, so we avoid hostname resolution.
+        final InetSocketAddress hostAndPort = InetSocketAddress.createUnresolved(host, port);
+        if (credentials.containsKey(hostAndPort)) {
+            throw new RuntimeException("Credentials already registered for this host ans port");
+        } else {
+            credentials.put(hostAndPort, new PasswordAuthentication(username, password.toCharArray()));
+        }
+    }
+
+    @Override
+    protected PasswordAuthentication getPasswordAuthentication() {
+        if (!"SOCKS5".equals(this.getRequestingProtocol())) {
+            return null;
+        }
+
+        // InetSocketAddress is just a tuple holder in this case, so we avoid hostname resolution.
+        final InetSocketAddress hostAndPort =
+            InetSocketAddress.createUnresolved(this.getRequestingHost(), this.getRequestingPort());
+        return credentials.get(hostAndPort);
+    }
+}

--- a/storage/core/src/test/java/io/aiven/kafka/tieredstorage/storage/proxy/ProxyConfigTest.java
+++ b/storage/core/src/test/java/io/aiven/kafka/tieredstorage/storage/proxy/ProxyConfigTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.proxy;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProxyConfigTest {
+    @Test
+    void minimalConfig() {
+        final var config = new ProxyConfig(Map.of(
+            "host", "localhost",
+            "port", "1080"
+        ));
+        assertThat(config.host()).isEqualTo("localhost");
+        assertThat(config.port()).isEqualTo(1080);
+        assertThat(config.username()).isNull();
+        assertThat(config.password()).isNull();
+    }
+
+    @Test
+    void fullConfig() {
+        final var config = new ProxyConfig(Map.of(
+            "host", "localhost",
+            "port", "1080",
+            "username", "username",
+            "password", "password"
+        ));
+        assertThat(config.host()).isEqualTo("localhost");
+        assertThat(config.port()).isEqualTo(1080);
+        assertThat(config.username()).isEqualTo("username");
+        assertThat(config.password()).isEqualTo("password");
+    }
+
+    @Test
+    void noHost() {
+        assertThatThrownBy(() -> new ProxyConfig(Map.of(
+            "port", "1080"
+        )))
+            .isExactlyInstanceOf(ConfigException.class)
+            .hasMessage("Missing required configuration \"host\" which has no default value.");
+    }
+
+    @Test
+    void noPort() {
+        assertThatThrownBy(() -> new ProxyConfig(Map.of(
+            "host", "localhost"
+        )))
+            .isExactlyInstanceOf(ConfigException.class)
+            .hasMessage("Missing required configuration \"port\" which has no default value.");
+    }
+
+    @Test
+    void usernameWithoutPassword() {
+        assertThatThrownBy(() -> new ProxyConfig(Map.of(
+            "host", "localhost",
+            "port", "1080",
+            "username", "username"
+        )))
+            .isExactlyInstanceOf(ConfigException.class)
+            .hasMessage("Username and password must be provided together");
+    }
+
+    @Test
+    void passwordWithoutUsername() {
+        assertThatThrownBy(() -> new ProxyConfig(Map.of(
+            "host", "localhost",
+            "port", "1080",
+            "password", "password"
+        ))).isExactlyInstanceOf(ConfigException.class)
+            .hasMessage("Username and password must be provided together");
+    }
+}

--- a/storage/core/src/test/java/io/aiven/kafka/tieredstorage/storage/proxy/Socks5ProxyAuthenticatorTest.java
+++ b/storage/core/src/test/java/io/aiven/kafka/tieredstorage/storage/proxy/Socks5ProxyAuthenticatorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.proxy;
+
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class Socks5ProxyAuthenticatorTest {
+    // It's specifically invalid as a host name to check it works with such strings.
+    private static final String HOSTNAME = "! 😬 aaa&333 @#";
+    private static final String USERNAME = "user";
+    private static final String PASSWORD = "password";
+
+    @Test
+    void successfulAuth() {
+        final var auth = new Socks5ProxyAuthenticator();
+        auth.addCredentials(HOSTNAME, 100, USERNAME, PASSWORD);
+
+        final var result = auth.requestPasswordAuthenticationInstance(
+            HOSTNAME, null, 100, "SOCKS5", null, null, null, Authenticator.RequestorType.SERVER);
+        assertThat(result)
+            .extracting(PasswordAuthentication::getUserName)
+            .isEqualTo(USERNAME);
+        assertThat(result)
+            .extracting(PasswordAuthentication::getPassword)
+            .isEqualTo(PASSWORD.toCharArray());
+    }
+
+    @Test
+    void multipleHostsAndPorts() {
+        final var auth = new Socks5ProxyAuthenticator();
+        auth.addCredentials(HOSTNAME, 100, USERNAME, PASSWORD);
+        auth.addCredentials("another host", 100, USERNAME, PASSWORD);
+        auth.addCredentials(HOSTNAME, 101, USERNAME, PASSWORD);
+
+        final var result = auth.requestPasswordAuthenticationInstance(
+            HOSTNAME, null, 100, "SOCKS5", null, null, null, Authenticator.RequestorType.SERVER);
+        assertThat(result)
+            .extracting(PasswordAuthentication::getUserName)
+            .isEqualTo(USERNAME);
+        assertThat(result)
+            .extracting(PasswordAuthentication::getPassword)
+            .isEqualTo(PASSWORD.toCharArray());
+    }
+
+    @Test
+    void authWithoutCredentialsRegistered() {
+        final var auth = new Socks5ProxyAuthenticator();
+
+        final var result = auth.requestPasswordAuthenticationInstance(
+            HOSTNAME, null, 100, "SOCKS5", null, null, null, Authenticator.RequestorType.SERVER);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void differentHost() {
+        final var auth = new Socks5ProxyAuthenticator();
+        auth.addCredentials("some other host", 100, USERNAME, PASSWORD);
+
+        final var result = auth.requestPasswordAuthenticationInstance(
+            "127.0.0.1", null, 100, "SOCKS5", null, null, null, Authenticator.RequestorType.SERVER);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void differentPort() {
+        final var auth = new Socks5ProxyAuthenticator();
+        auth.addCredentials(HOSTNAME, 100, USERNAME, PASSWORD);
+
+        final var result = auth.requestPasswordAuthenticationInstance(
+            HOSTNAME, null, 200, "SOCKS5", null, null, null, Authenticator.RequestorType.SERVER);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void differentProtocol() {
+        final var auth = new Socks5ProxyAuthenticator();
+        auth.addCredentials(HOSTNAME, 100, USERNAME, PASSWORD);
+
+        final var result = auth.requestPasswordAuthenticationInstance(
+            HOSTNAME, null, 100, "HTTP", null, null, null, Authenticator.RequestorType.SERVER);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void addingShouldNotSupportIncorrectValues() {
+        final var auth = new Socks5ProxyAuthenticator();
+        assertThatThrownBy(() -> auth.addCredentials(null, 100, USERNAME, PASSWORD))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("host cannot be null");
+        assertThatThrownBy(() -> auth.addCredentials(HOSTNAME, 0, USERNAME, PASSWORD))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("port must be positive");
+        assertThatThrownBy(() -> auth.addCredentials(HOSTNAME, 100, null, PASSWORD))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("username cannot be null");
+        assertThatThrownBy(() -> auth.addCredentials(HOSTNAME, 100, USERNAME, null))
+            .isExactlyInstanceOf(NullPointerException.class)
+            .hasMessage("password cannot be null");
+    }
+
+    @Test
+    void overridingCredentialsShouldNotBeAllowed() {
+        final var auth = new Socks5ProxyAuthenticator();
+        auth.addCredentials(HOSTNAME, 100, USERNAME, PASSWORD);
+        assertThatThrownBy(() -> auth.addCredentials(HOSTNAME, 100, "other", "other"))
+            .isExactlyInstanceOf(RuntimeException.class)
+            .hasMessage("Credentials already registered for this host ans port");
+    }
+}

--- a/storage/core/src/testFixtures/java/io/aiven/kafka/tieredstorage/storage/BaseSocks5Test.java
+++ b/storage/core/src/testFixtures/java/io/aiven/kafka/tieredstorage/storage/BaseSocks5Test.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public abstract class BaseSocks5Test<T extends StorageBackend> {
+    protected static final int SOCKS5_PORT = 1080;
+    protected static final String SOCKS5_USER = "user";
+    protected static final String SOCKS5_PASSWORD = "password";
+
+    protected static final ObjectKey OBJECT_KEY = () -> "aaa";
+    protected static final byte[] TEST_DATA = {0, 1, 2, 3};
+
+    protected static GenericContainer<?> proxyContainer(final boolean authenticated) {
+        final Map<String, String> config = new HashMap<>();
+        config.put("LISTEN", "0.0.0.0:" + SOCKS5_PORT);
+        if (authenticated) {
+            config.put("USER", SOCKS5_USER);
+            config.put("PASSWORD", SOCKS5_PASSWORD);
+        }
+
+        return new GenericContainer<>(DockerImageName.parse("ananclub/ss5"))
+            .withEnv(config)
+            .withExposedPorts(SOCKS5_PORT);
+    }
+
+    protected abstract T createStorageBackend();
+
+
+    @Test
+    void worksWithAuthenticatedProxy() throws StorageBackendException, IOException {
+        // Ensure we can access the storage through the proxy with authentication.
+        final T storage = createStorageBackend();
+        storage.configure(storageConfigForAuthenticatedProxy());
+
+        storage.upload(new ByteArrayInputStream(TEST_DATA), OBJECT_KEY);
+        assertThat(storage.fetch(OBJECT_KEY).readAllBytes()).isEqualTo(TEST_DATA);
+    }
+
+    protected abstract Map<String, Object> storageConfigForAuthenticatedProxy();
+
+    @Test
+    void worksWithUnauthenticatedProxy() throws StorageBackendException, IOException {
+        // Ensure we can access the storage through the proxy without authentication.
+        final T storage = createStorageBackend();
+        storage.configure(storageConfigForUnauthenticatedProxy());
+
+        storage.upload(new ByteArrayInputStream(TEST_DATA), OBJECT_KEY);
+        assertThat(storage.fetch(OBJECT_KEY).readAllBytes()).isEqualTo(TEST_DATA);
+    }
+
+    protected abstract Map<String, Object> storageConfigForUnauthenticatedProxy();
+
+    @Test
+    void doesNotWorkWithoutProxy() {
+        // This test accompanies the other ones by ensuring that _without_ a proxy
+        // we cannot even resolve the host name of the server, which is internal to the Docker network.
+
+        // Due to the nature to the Java name resolution and/or getaddrinfo,
+        // for some storage implementations this has a pretty long unconfigurable timeout,
+        // so the test may take a couple of minutes.
+
+        final T storage = createStorageBackend();
+        storage.configure(storageConfigForNoProxy());
+
+        assertThatThrownBy(() -> storage.upload(new ByteArrayInputStream(TEST_DATA), OBJECT_KEY))
+            .isExactlyInstanceOf(StorageBackendException.class)
+            .hasRootCauseInstanceOf(UnknownHostException.class)
+            .rootCause().message()
+            .isIn(possibleRootCauseMessagesWhenNoProxy());
+        assertThatThrownBy(() -> storage.fetch(OBJECT_KEY))
+            .isExactlyInstanceOf(StorageBackendException.class)
+            .hasRootCauseInstanceOf(UnknownHostException.class)
+            .rootCause().message()
+            .isIn(possibleRootCauseMessagesWhenNoProxy());
+    }
+
+    protected abstract Map<String, Object> storageConfigForNoProxy();
+
+    protected abstract Iterable<String> possibleRootCauseMessagesWhenNoProxy();
+}

--- a/storage/core/src/testFixtures/java/io/aiven/kafka/tieredstorage/storage/TestUtils.java
+++ b/storage/core/src/testFixtures/java/io/aiven/kafka/tieredstorage/storage/TestUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage;
+
+import org.junit.jupiter.api.TestInfo;
+
+public class TestUtils {
+    public static String testNameToBucketName(final TestInfo testInfo) {
+        String bucketName = testInfo.getDisplayName()
+            .toLowerCase()
+            .replace(" ", "")
+            .replace(",", "-")
+            .replace("(", "")
+            .replace(")", "")
+            .replace("[", "")
+            .replace("]", "");
+        while (bucketName.length() < 3) {
+            bucketName += bucketName;
+        }
+        return bucketName;
+    }
+}

--- a/storage/gcs/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/gcs/GcsStorageMetricsTest.java
+++ b/storage/gcs/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/gcs/GcsStorageMetricsTest.java
@@ -30,6 +30,7 @@ import io.aiven.kafka.tieredstorage.storage.BytesRange;
 import io.aiven.kafka.tieredstorage.storage.ObjectKey;
 import io.aiven.kafka.tieredstorage.storage.StorageBackendException;
 import io.aiven.kafka.tieredstorage.storage.TestObjectKey;
+import io.aiven.kafka.tieredstorage.storage.TestUtils;
 import io.aiven.testcontainers.fakegcsserver.FakeGcsServerContainer;
 
 import com.google.cloud.NoCredentials;
@@ -73,13 +74,7 @@ public class GcsStorageMetricsTest {
 
     @BeforeEach
     void setUp(final TestInfo testInfo) {
-        String bucketName = testInfo.getDisplayName()
-            .toLowerCase()
-            .replace("(", "")
-            .replace(")", "");
-        while (bucketName.length() < 3) {
-            bucketName += bucketName;
-        }
+        final String bucketName = TestUtils.testNameToBucketName(testInfo);
         storageClient.create(BucketInfo.newBuilder(bucketName).build());
 
         storage = new GcsStorage();

--- a/storage/gcs/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/gcs/GcsStorageSocks5Test.java
+++ b/storage/gcs/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/gcs/GcsStorageSocks5Test.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.gcs;
+
+import java.util.List;
+import java.util.Map;
+
+import io.aiven.kafka.tieredstorage.storage.BaseSocks5Test;
+import io.aiven.testcontainers.fakegcsserver.FakeGcsServerContainer;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class GcsStorageSocks5Test extends BaseSocks5Test<GcsStorage> {
+    static final Network NETWORK = Network.newNetwork();
+
+    @Container
+    static final FakeGcsServerContainer GCS_SERVER = new FakeGcsServerContainer()
+        .withNetwork(NETWORK);
+
+    static String fakeGcsContainerNetworkAlias = GCS_SERVER.getNetworkAliases().get(0);
+
+    static String internalGcsEndpoint;
+
+    static {
+        internalGcsEndpoint = String.format("http://%s:%d", fakeGcsContainerNetworkAlias, GCS_SERVER.PORT);
+        GCS_SERVER.withExternalURL(internalGcsEndpoint);
+    }
+
+    @Container
+    static final GenericContainer<?> PROXY_AUTHENTICATED = proxyContainer(true).withNetwork(NETWORK);
+    @Container
+    static final GenericContainer<?> PROXY_UNAUTHENTICATED = proxyContainer(false).withNetwork(NETWORK);
+
+    static Storage storage;
+
+    private String bucketName;
+
+    @BeforeAll
+    static void setUpClass() {
+        storage = StorageOptions.newBuilder()
+            .setCredentials(NoCredentials.getInstance())
+            .setHost(GCS_SERVER.url())
+            .setProjectId("test-project")
+            .build()
+            .getService();
+    }
+
+    @BeforeEach
+    void setUp(final TestInfo testInfo) {
+        bucketName = testInfo.getDisplayName()
+            .toLowerCase()
+            .replace("(", "")
+            .replace(")", "");
+        while (bucketName.length() < 3) {
+            bucketName += bucketName;
+        }
+        storage.create(BucketInfo.newBuilder(bucketName).build());
+    }
+
+    @Override
+    protected GcsStorage createStorageBackend() {
+        return new GcsStorage();
+    }
+
+    @Override
+    protected Map<String, Object> storageConfigForAuthenticatedProxy() {
+        final var proxy = PROXY_AUTHENTICATED;
+        return Map.of(
+            "gcs.endpoint.url", internalGcsEndpoint,
+            "gcs.bucket.name", bucketName,
+            "gcs.credentials.default", "false",
+            "proxy.host", proxy.getHost(),
+            "proxy.port", proxy.getMappedPort(SOCKS5_PORT),
+            "proxy.username", SOCKS5_USER,
+            "proxy.password", SOCKS5_PASSWORD
+        );
+    }
+
+    @Override
+    protected Map<String, Object> storageConfigForUnauthenticatedProxy() {
+        final var proxy = PROXY_UNAUTHENTICATED;
+        return Map.of(
+            "gcs.endpoint.url", internalGcsEndpoint,
+            "gcs.bucket.name", bucketName,
+            "gcs.credentials.default", "false",
+            "proxy.host", proxy.getHost(),
+            "proxy.port", proxy.getMappedPort(SOCKS5_PORT)
+        );
+    }
+
+    @Override
+    protected Map<String, Object> storageConfigForNoProxy() {
+        return Map.of(
+            "gcs.endpoint.url", internalGcsEndpoint,
+            "gcs.bucket.name", bucketName,
+            "gcs.credentials.default", "false"
+        );
+    }
+
+    @Override
+    protected Iterable<String> possibleRootCauseMessagesWhenNoProxy() {
+        return List.of(fakeGcsContainerNetworkAlias);
+    }
+}

--- a/storage/gcs/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/gcs/GcsStorageSocks5Test.java
+++ b/storage/gcs/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/gcs/GcsStorageSocks5Test.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.aiven.kafka.tieredstorage.storage.BaseSocks5Test;
+import io.aiven.kafka.tieredstorage.storage.TestUtils;
 import io.aiven.testcontainers.fakegcsserver.FakeGcsServerContainer;
 
 import com.google.cloud.NoCredentials;
@@ -72,13 +73,7 @@ class GcsStorageSocks5Test extends BaseSocks5Test<GcsStorage> {
 
     @BeforeEach
     void setUp(final TestInfo testInfo) {
-        bucketName = testInfo.getDisplayName()
-            .toLowerCase()
-            .replace("(", "")
-            .replace(")", "");
-        while (bucketName.length() < 3) {
-            bucketName += bucketName;
-        }
+        bucketName = TestUtils.testNameToBucketName(testInfo);
         storage.create(BucketInfo.newBuilder(bucketName).build());
     }
 

--- a/storage/gcs/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/gcs/GcsStorageTest.java
+++ b/storage/gcs/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/gcs/GcsStorageTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import io.aiven.kafka.tieredstorage.storage.BaseStorageTest;
 import io.aiven.kafka.tieredstorage.storage.StorageBackend;
+import io.aiven.kafka.tieredstorage.storage.TestUtils;
 import io.aiven.testcontainers.fakegcsserver.FakeGcsServerContainer;
 
 import com.google.cloud.NoCredentials;
@@ -52,13 +53,7 @@ class GcsStorageTest extends BaseStorageTest {
 
     @BeforeEach
     void setUp(final TestInfo testInfo) {
-        bucketName = testInfo.getDisplayName()
-            .toLowerCase()
-            .replace("(", "")
-            .replace(")", "");
-        while (bucketName.length() < 3) {
-            bucketName += bucketName;
-        }
+        bucketName = TestUtils.testNameToBucketName(testInfo);
         storage.create(BucketInfo.newBuilder(bucketName).build());
     }
 

--- a/storage/gcs/src/main/java/io/aiven/kafka/tieredstorage/storage/gcs/GcsStorageConfig.java
+++ b/storage/gcs/src/main/java/io/aiven/kafka/tieredstorage/storage/gcs/GcsStorageConfig.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.config.types.Password;
 
 import io.aiven.kafka.tieredstorage.config.validators.NonEmptyPassword;
 import io.aiven.kafka.tieredstorage.config.validators.ValidUrl;
+import io.aiven.kafka.tieredstorage.storage.proxy.ProxyConfig;
 
 import com.google.auth.Credentials;
 
@@ -104,9 +105,20 @@ class GcsStorageConfig extends AbstractConfig {
                 GCP_CREDENTIALS_DEFAULT_DOC);
     }
 
+    private ProxyConfig proxyConfig = null;
+
     public GcsStorageConfig(final Map<String, ?> props) {
         super(CONFIG, props);
         validate();
+
+        final Map<String, ?> proxyProps = this.originalsWithPrefix(ProxyConfig.PROXY_PREFIX, true);
+        if (!proxyProps.isEmpty()) {
+            this.proxyConfig = new ProxyConfig(proxyProps);
+        }
+    }
+
+    ProxyConfig proxyConfig() {
+        return proxyConfig;
     }
 
     private void validate() {

--- a/storage/gcs/src/main/java/io/aiven/kafka/tieredstorage/storage/gcs/MetricCollector.java
+++ b/storage/gcs/src/main/java/io/aiven/kafka/tieredstorage/storage/gcs/MetricCollector.java
@@ -129,8 +129,8 @@ class MetricCollector {
         }
     }
 
-    HttpTransportOptions httpTransportOptions() {
-        return new HttpTransportOptions(HttpTransportOptions.newBuilder()) {
+    HttpTransportOptions httpTransportOptions(final HttpTransportOptions.Builder builder) {
+        return new HttpTransportOptions(builder) {
             @Override
             public HttpRequestInitializer getHttpRequestInitializer(final ServiceOptions<?, ?> serviceOptions) {
                 final var superInitializer = super.getHttpRequestInitializer(serviceOptions);

--- a/storage/gcs/src/main/java/io/aiven/kafka/tieredstorage/storage/gcs/ProxiedHttpTransportFactory.java
+++ b/storage/gcs/src/main/java/io/aiven/kafka/tieredstorage/storage/gcs/ProxiedHttpTransportFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.gcs;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.auth.http.HttpTransportFactory;
+
+class ProxiedHttpTransportFactory implements HttpTransportFactory {
+    private final InetSocketAddress proxy;
+
+    ProxiedHttpTransportFactory(final String host, final int port) {
+        this.proxy = new InetSocketAddress(host, port);
+    }
+
+    @Override
+    public HttpTransport create() {
+        return new NetHttpTransport.Builder()
+            .setProxy(new Proxy(Proxy.Type.SOCKS, proxy))
+            .build();
+    }
+}

--- a/storage/s3/build.gradle
+++ b/storage/s3/build.gradle
@@ -23,15 +23,12 @@ ext {
 dependencies {
     implementation project(":storage:core")
 
-    // Take out jackson libraries out to avoid collision with core jackson dependencies
-    implementation ("software.amazon.awssdk:s3:$awsSdkVersion") {
-        exclude group: "com.fasterxml.jackson.core"
-        exclude group: "com.fasterxml.jackson.dataformat"
-        exclude group: "org.slf4j"
+    def excludeFromAWSDeps = { ModuleDependency dep ->
+        dep.exclude group: "org.slf4j"
     }
-    // replacing with version used by core
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:$jacksonVersion"
+    implementation ("software.amazon.awssdk:s3:$awsSdkVersion") {excludeFromAWSDeps(it)}
+    runtimeOnly ("software.amazon.awssdk:sts:$awsSdkVersion") {excludeFromAWSDeps(it)}
+
     implementation project(':commons')
 
     testImplementation(testFixtures(project(":storage:core")))

--- a/storage/s3/build.gradle
+++ b/storage/s3/build.gradle
@@ -29,6 +29,12 @@ dependencies {
     implementation ("software.amazon.awssdk:s3:$awsSdkVersion") {excludeFromAWSDeps(it)}
     runtimeOnly ("software.amazon.awssdk:sts:$awsSdkVersion") {excludeFromAWSDeps(it)}
 
+    implementation ("software.amazon.awssdk:netty-nio-client:$awsSdkVersion") { excludeFromAWSDeps(it) }
+    runtimeOnly group: 'io.netty', name: 'netty-tcnative-boringssl-static', version: '2.0.65.Final', classifier: "linux-aarch_64"
+    runtimeOnly group: 'io.netty', name: 'netty-tcnative-boringssl-static', version: '2.0.65.Final', classifier: "linux-x86_64"
+    runtimeOnly group: 'io.netty', name: 'netty-tcnative-boringssl-static', version: '2.0.65.Final', classifier: "osx-aarch_64"
+    runtimeOnly group: 'io.netty', name: 'netty-tcnative-boringssl-static', version: '2.0.65.Final', classifier: "osx-x86_64"
+
     implementation project(':commons')
 
     testImplementation(testFixtures(project(":storage:core")))

--- a/storage/s3/build.gradle
+++ b/storage/s3/build.gradle
@@ -17,7 +17,7 @@
 archivesBaseName = "storage-s3"
 
 ext {
-    wireMockVersion = "3.3.1"
+    wireMockVersion = "3.5.2"
 }
 
 dependencies {

--- a/storage/s3/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageTest.java
+++ b/storage/s3/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import io.aiven.kafka.tieredstorage.storage.BaseStorageTest;
 import io.aiven.kafka.tieredstorage.storage.StorageBackend;
 import io.aiven.kafka.tieredstorage.storage.TestObjectKey;
+import io.aiven.kafka.tieredstorage.storage.TestUtils;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,10 +67,7 @@ public class S3StorageTest extends BaseStorageTest {
 
     @BeforeEach
     void setUp(final TestInfo testInfo) {
-        bucketName = testInfo.getDisplayName()
-            .toLowerCase()
-            .replace("(", "")
-            .replace(")", "");
+        bucketName = TestUtils.testNameToBucketName(testInfo);
         s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
     }
 

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3ClientBuilder.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3ClientBuilder.java
@@ -19,15 +19,16 @@ package io.aiven.kafka.tieredstorage.storage.s3;
 import java.util.Objects;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder;
+import software.amazon.awssdk.core.internal.http.loader.DefaultSdkAsyncHttpClientBuilder;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.utils.AttributeMap;
 
 class S3ClientBuilder {
-    static S3Client build(final S3StorageConfig config) {
-        final software.amazon.awssdk.services.s3.S3ClientBuilder s3ClientBuilder = S3Client.builder();
+    static S3AsyncClient build(final S3StorageConfig config) {
+        final software.amazon.awssdk.services.s3.S3AsyncClientBuilder s3ClientBuilder = S3AsyncClient.builder();
         final Region region = config.region();
         if (Objects.isNull(config.s3ServiceEndpoint())) {
             s3ClientBuilder.region(region);
@@ -38,10 +39,10 @@ class S3ClientBuilder {
         if (config.pathStyleAccessEnabled() != null) {
             s3ClientBuilder.forcePathStyle(config.pathStyleAccessEnabled());
         }
-
+        s3ClientBuilder.httpClient(NettyNioAsyncHttpClient.builder().build());
         if (!config.certificateCheckEnabled()) {
             s3ClientBuilder.httpClient(
-                new DefaultSdkHttpClientBuilder()
+                new DefaultSdkAsyncHttpClientBuilder()
                     .buildWithDefaults(
                         AttributeMap.builder()
                             .put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, true)


### PR DESCRIPTION
This change uses the async s3 client instead of the sync client.
This is enable to use netty async client with native SSL bindings and will make the transition to using S3 crt client possible.

Add netty tcnative boring SSL dependencies at runtime
